### PR TITLE
text type for "up" and "down" fields (without lenght limit)

### DIFF
--- a/src/ConsoleTools/Model/Migration.php
+++ b/src/ConsoleTools/Model/Migration.php
@@ -53,10 +53,10 @@ class Migration
     public function createTable()
     {
         $sql = "
-            CREATE TABLE IF NOT EXISTS `".self::TABLE."`(
+            CREATE TABLE IF NOT EXISTS `" . self::TABLE . "`(
                 `migration` VARCHAR(20) NOT NULL,
-                `up` VARCHAR(1000) NOT NULL,
-                `down` VARCHAR(1000) NOT NULL
+                `up` text NOT NULL,
+                `down` text NOT NULL
             ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
         ";
 


### PR DESCRIPTION
We don't know how long can be a text of migration, so fields should be flexible.